### PR TITLE
Switch Reddit integration to official OAuth API

### DIFF
--- a/app/controllers/reddit_controller.rb
+++ b/app/controllers/reddit_controller.rb
@@ -1,19 +1,53 @@
 require "net/http"
 
 class RedditController < ApplicationController
-  BASE_URL = "https://old.reddit.com"
+  API_BASE_URL = "https://oauth.reddit.com"
+  TOKEN_URL = "https://www.reddit.com/api/v1/access_token"
+  TOKEN_CACHE_KEY = "reddit:access_token".freeze
 
   def subreddit
-    search_results = perform_search
-    render json: feed(search_results)
+    listing = fetch_listing(params[:subreddit])
+    render json: feed(listing)
   end
 
   private
 
-  def perform_search
-    uri = URI("#{BASE_URL}/r/#{params[:subreddit]}.json")
-    response = HttpRequest.new(uri, proxy: true).get
+  def fetch_listing(subreddit)
+    uri = URI("#{API_BASE_URL}/r/#{subreddit}")
+    response = HttpRequest.new(uri, headers: {
+      "Authorization" => "Bearer #{access_token}"
+    }).get
     JSON.parse(response.body)
+  end
+
+  # Application-only OAuth (client_credentials). The token is cached until just
+  # before it expires, so we re-authenticate at most once per token lifetime
+  # rather than on every request.
+  def access_token
+    Rails.cache.read(TOKEN_CACHE_KEY) || fetch_and_cache_token
+  end
+
+  def fetch_and_cache_token
+    body = request_token
+    ttl = [ body.fetch("expires_in", 3600).to_i - 60, 60 ].max
+    Rails.cache.write(TOKEN_CACHE_KEY, body["access_token"], expires_in: ttl)
+    body["access_token"]
+  end
+
+  def request_token
+    response = HttpRequest.new(URI(TOKEN_URL), headers: {
+      "Authorization" => "Basic #{client_credentials}",
+      "Content-Type" => "application/x-www-form-urlencoded"
+    }).post("grant_type=client_credentials")
+
+    raise "Reddit authentication failed: #{response.body}" unless response.code == "200"
+
+    JSON.parse(response.body)
+  end
+
+  def client_credentials
+    creds = Rails.application.credentials
+    [ "#{creds.reddit_client_id!}:#{creds.reddit_client_secret!}" ].pack("m0")
   end
 
   def items(search_results)

--- a/test/controllers/reddit_controller_test.rb
+++ b/test/controllers/reddit_controller_test.rb
@@ -1,8 +1,12 @@
 require "test_helper"
 
 class RedditControllerTest < ActionDispatch::IntegrationTest
+  # Reddit's application-only OAuth token response.
+  TOKEN = FakeResponse.json({ "access_token" => "reddit-token", "expires_in" => 3600 })
+
   # A minimal subreddit listing: one image post and one self/text post. Kept
   # small and gfycat/oembed-free on purpose so rendering stays deterministic.
+  # oauth.reddit.com returns the same Listing shape as the old .json scrape.
   LISTING = {
     "data" => {
       "children" => [
@@ -30,7 +34,7 @@ class RedditControllerTest < ActionDispatch::IntegrationTest
   }.freeze
 
   test "returns a JSON Feed for the subreddit" do
-    stub_http("old.reddit.com/r/test.json" => FakeResponse.json(LISTING)) do
+    with_reddit("oauth.reddit.com/r/test" => FakeResponse.json(LISTING)) do
       get "/reddit/test"
     end
 
@@ -44,7 +48,7 @@ class RedditControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "maps a post into a feed item with rendered content" do
-    stub_http("old.reddit.com/r/test.json" => FakeResponse.json(LISTING)) do
+    with_reddit("oauth.reddit.com/r/test" => FakeResponse.json(LISTING)) do
       get "/reddit/test"
     end
 
@@ -57,33 +61,62 @@ class RedditControllerTest < ActionDispatch::IntegrationTest
     assert_equal "https://old.reddit.com/user/alice", item["authors"].first["url"]
   end
 
-  test "requests the subreddit from the listing endpoint through the proxy" do
-    requested = nil
-    options = nil
+  test "authenticates with client_credentials then fetches via the OAuth API with no proxy" do
+    calls = []
     HttpRequest.define_singleton_method(:new) do |url, **opts|
-      requested = url.to_s
-      options = opts
-      FakeHttpRequest.new(url, "test.json" => FakeResponse.json(LISTING))
+      fake = Object.new
+      fake.define_singleton_method(:get) do
+        calls << { url: url.to_s, opts: opts, method: :get }
+        FakeResponse.json(LISTING)
+      end
+      fake.define_singleton_method(:post) do |body = nil|
+        calls << { url: url.to_s, opts: opts, method: :post, body: body }
+        FakeResponse.json({ "access_token" => "reddit-token", "expires_in" => 3600 })
+      end
+      fake
     end
 
     begin
-      get "/reddit/test"
+      stub_credentials(reddit_client_id!: "id", reddit_client_secret!: "secret") do
+        get "/reddit/test"
+      end
     ensure
       HttpRequest.singleton_class.send(:remove_method, :new)
     end
 
-    assert_equal "https://old.reddit.com/r/test.json", requested
-    # Reddit blocks the server's IP, so the listing must be fetched via the proxy.
-    assert_equal true, options[:proxy]
+    token_call = calls.find { |c| c[:method] == :post }
+    listing_call = calls.find { |c| c[:method] == :get }
+
+    # Token request: application-only grant with the client id/secret as HTTP Basic auth.
+    assert_includes token_call[:url], "www.reddit.com/api/v1/access_token"
+    assert_equal "grant_type=client_credentials", token_call[:body]
+    assert_equal "Basic #{[ "id:secret" ].pack("m0")}", token_call.dig(:opts, :headers, "Authorization")
+
+    # Listing request: OAuth host, bearer token, and no proxy (OAuth replaces the IP workaround).
+    assert_equal "https://oauth.reddit.com/r/test", listing_call[:url]
+    assert_equal "Bearer reddit-token", listing_call.dig(:opts, :headers, "Authorization")
+    assert_nil listing_call.dig(:opts, :proxy)
   end
 
-  # End-to-end against a real old.reddit.com/r/aww.json capture. This is the
-  # only test that exercises the content view's video and gallery branches with
-  # genuine Reddit payloads (entity-escaped urls, crosspost metadata, etc.).
+  test "raises when the OAuth token request fails" do
+    error = assert_raises(RuntimeError) do
+      stub_credentials(reddit_client_id!: "id", reddit_client_secret!: "secret") do
+        stub_http("access_token" => FakeResponse.new("401", "forbidden")) do
+          get "/reddit/test"
+        end
+      end
+    end
+
+    assert_match(/authentication failed/i, error.message)
+  end
+
+  # End-to-end against a real r/aww capture. This is the only test that exercises
+  # the content view's video and gallery branches with genuine Reddit payloads
+  # (entity-escaped urls, crosspost metadata, etc.).
   test "renders real video and gallery posts from a captured listing" do
     listing = JSON.parse(File.read(Rails.root.join("test/support/subreddit.json")))
 
-    stub_http("old.reddit.com/r/aww.json" => FakeResponse.json(listing)) do
+    with_reddit("oauth.reddit.com/r/aww" => FakeResponse.json(listing)) do
       get "/reddit/aww"
     end
 
@@ -98,5 +131,15 @@ class RedditControllerTest < ActionDispatch::IntegrationTest
 
     gallery = items.find { |item| item["id"] == "1fg1i35" }
     assert_equal 3, gallery["content_html"].scan("<img").size
+  end
+
+  private
+
+  # Stubs the Reddit credentials and both HTTP calls (token + listing). The
+  # token endpoint is matched by the "access_token" url fragment.
+  def with_reddit(responses, &block)
+    stub_credentials(reddit_client_id!: "id", reddit_client_secret!: "secret") do
+      stub_http({ "access_token" => TOKEN }.merge(responses), &block)
+    end
   end
 end


### PR DESCRIPTION
## What

Switches the Reddit integration from scraping `old.reddit.com/r/{sub}.json` (through a proxy) to Reddit's **official API** with **application-only OAuth** (`client_credentials`), modeled on the existing `BlueskyController`.

## How

- `POST https://www.reddit.com/api/v1/access_token` — client id/secret sent as HTTP Basic auth, body `grant_type=client_credentials`.
- `GET https://oauth.reddit.com/r/{subreddit}` — with `Authorization: Bearer <token>`. `HttpRequest` already injects the required `user_agent`.
- Token cached in `Rails.cache` until just before `expires_in`, so we re-auth at most once per token lifetime (in test the cache is `:null_store`, so it just re-auths).
- **Proxy dropped** for Reddit — authenticated OAuth requests are allowed from the server.

`oauth.reddit.com` returns the **same Listing JSON** as the scrape (same HTML-escaped URLs, no `raw_json=1`), so `RedditPost`, the content view, and the feed builder are **unchanged**. base64 uses `pack("m0")` to avoid a gem dependency (Ruby 4.0 drops `base64` from default gems).

## Tests

`reddit_controller_test.rb` rewritten to stub the token + `oauth.reddit.com` calls and assert the full OAuth contract: `client_credentials` grant with Basic client auth, Bearer-token listing fetch, OAuth host, and **no proxy**. Added an auth-failure test. `RedditPost` model tests and the real-fixture render test are unchanged (same JSON shape).

Local: full suite 27 runs / 96 assertions green; rubocop clean; brakeman 0 warnings.

## ⚠️ Do not merge/deploy until credentials are set

Needs new credentials `reddit_client_id` + `reddit_client_secret`. Without them, live Reddit feeds will 500 (`KeyError: reddit_client_id is blank`). Setup steps are in the chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
